### PR TITLE
some module purge lines in submission scripts

### DIFF
--- a/LAMMPS/SLURM/lammps_cpu.slurm
+++ b/LAMMPS/SLURM/lammps_cpu.slurm
@@ -6,6 +6,7 @@
 #SBATCH --mem=12GB
 #SBATCH --time=1:00:00
 
+module purge
 module load openmpi/5.0.1
 
 export PATH=/home/$USER/software_slurm/lammps-2Aug2023/build-openmpi-omp:$PATH

--- a/LAMMPS/SLURM/lammps_cpu_amd.slurm
+++ b/LAMMPS/SLURM/lammps_cpu_amd.slurm
@@ -7,6 +7,7 @@
 #SBATCH --time=1:00:00
 #SBATCH --constraint=cpu_gen_genoa
 
+module purge
 module load aocc lammps
 
 cd $SLURM_SUBMIT_DIR

--- a/LAMMPS/SLURM/lammps_gpu.slurm
+++ b/LAMMPS/SLURM/lammps_gpu.slurm
@@ -6,6 +6,7 @@
 #SBATCH --mem=12GB
 #SBATCH --time=1:00:00
 
+module purge
 module load cuda/11.8.0 openmpi/5.0.1
 
 export PATH=/home/$USER/software_slurm/lammps-2Aug2023/build-kokkos-gpu-omp:$PATH

--- a/LAMMPS/SLURM/lammps_install.slurm
+++ b/LAMMPS/SLURM/lammps_install.slurm
@@ -19,6 +19,7 @@ cp ../cmake/presets/basic.cmake ../cmake/presets/basic-gpu-omp.cmake
 cp ../cmake/presets/kokkos-cuda.cmake ../cmake/presets/kokkos-a100.cmake
 sed -i "s/set(ALL_PACKAGES KSPACE MANYBODY MOLECULE RIGID)/set(ALL_PACKAGES KSPACE MANYBODY MOLECULE RIGID GPU OPENMP USER-OMP)/g" ../cmake/presets/basic-gpu-omp.cmake
 sed -i "s/PASCAL60/AMPERE80/g" ../cmake/presets/kokkos-a100.cmake
+module purge
 module load cuda/11.8.0 openmpi/5.0.1 
 cmake -C ../cmake/presets/basic-gpu-omp.cmake -C ../cmake/presets/kokkos-a100.cmake -DKokkos_ENABLE_OPENMP=yes ../cmake
 cmake --build . --parallel 12


### PR DESCRIPTION
Hello,

I ran through the LAMMPS examples and they did not work, for what I suspect to be some module conflicts. I added some `module purge` lines to the installation and example run submission scripts and it worked fine from there. These changes might be of some assistance to other Palmetto users who might not be familiar with resolving module conflicts.